### PR TITLE
Updates outdated swagger parser  (#24)

### DIFF
--- a/.github/workflows/hw1.yaml
+++ b/.github/workflows/hw1.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [14]
+        node: [16]
     runs-on: ${{ matrix.os }}
     env:
       TEST_ENV: ${{ matrix.test_env || 'production' }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [14]
+        node: [16]
     runs-on: ${{ matrix.os }}
     env:
       TEST_ENV: ${{ matrix.test_env || 'production' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,12 +25,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [14, 16, 18]
+        node: [16, 18]
         database: [mongo-dev, mongo, redis, postgres]
         include:
           # only run coverage once
           - os: ubuntu-latest
-            node: 14
+            node: 16
             coverage: true
           # test under development once
           - database: mongo-dev

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![NodeBB](public/images/sm-card.png)
 
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0) 
 
 [**NodeBB Forum Software**](https://nodebb.org) is powered by Node.js and supports either Redis, MongoDB, or a PostgreSQL database. It utilizes web sockets for instant interactions and real-time notifications. NodeBB takes the best of the modern web: real-time streaming discussions, mobile responsiveness, and rich RESTful read/write APIs, while staying true to the original bulletin board/forum format &rarr; categorical hierarchies, local user accounts, and asynchronous messaging.
 

--- a/install/package.json
+++ b/install/package.json
@@ -97,6 +97,7 @@
         "nodebb-plugin-dbsearch": "5.1.5",
         "nodebb-plugin-emoji": "4.0.6",
         "nodebb-plugin-emoji-android": "3.0.0",
+        "nodebb-plugin-location-to-map": "^0.1.1",
         "nodebb-plugin-markdown": "10.1.1",
         "nodebb-plugin-mentions": "3.0.12",
         "nodebb-plugin-spam-be-gone": "1.0.2",
@@ -145,7 +146,7 @@
         "zxcvbn": "4.4.2"
     },
     "devDependencies": {
-        "@apidevtools/swagger-parser": "10.0.3",
+        "@apidevtools/swagger-parser": "^10.1.0",
         "@commitlint/cli": "17.3.0",
         "@commitlint/config-angular": "17.3.0",
         "@types/async": "^3.2.16",
@@ -178,7 +179,7 @@
         "url": "https://github.com/NodeBB/NodeBB/issues"
     },
     "engines": {
-        "node": ">=12"
+        "node": ">=16"
     },
     "maintainers": [
         {


### PR DESCRIPTION
* Add whitespace

* Update swagger-parser

* Update package.json

* Add ajv

* Do a downgrade of swagger-parser

* Update node version and swagger

* Remove test case for node 14

* Update lint env to 16

* Update hw1 to 16